### PR TITLE
Harden the image and both pipelines, and make the walkthrough work today

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,27 +86,35 @@ jobs:
       # `docker login -p <token>` command: the token lands in the process list and in
       # the build log. `get-login` was also removed in AWS CLI v2.
       #
-      # AWS_ACCOUNT_ID, AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY come from the
-      # project's environment variables. CircleCI has no instance metadata, so unlike
-      # the Jenkins pipeline this one does need a key; scope its IAM policy to ECR push
-      # on this one repository, as the README shows.
+      # The account ID comes from STS rather than an AWS_ACCOUNT_ID variable, so there
+      # is one fewer thing to set and no chance of it disagreeing with the key.
+      # AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY do come from the project's
+      # environment variables: CircleCI has no instance metadata, so unlike the Jenkins
+      # pipeline this one needs a key. Scope its IAM policy to ECR push on this one
+      # repository, as the README shows.
+      #
+      # This pushes ONLY the immutable SHA tag, where the Jenkins pipeline also moves
+      # :latest. That asymmetry is deliberate. Jenkins has disableConcurrentBuilds();
+      # CircleCI has no equivalent, so two master workflows can push at once and the one
+      # that finishes last wins :latest, which can leave the tag pointing at the older
+      # commit while both SHA tags are correct. A mutable tag that can silently go
+      # backwards is worse than no mutable tag, so promotion of :latest is left to the
+      # serialized pipeline or to a deliberate manual step.
       - run:
           name: Push to ECR
           command: |
-            registry_host="${AWS_ACCOUNT_ID}.dkr.ecr.<< pipeline.parameters.aws_region >>.amazonaws.com"
+            account=$(aws sts get-caller-identity --query Account --output text)
+            registry_host="${account}.dkr.ecr.<< pipeline.parameters.aws_region >>.amazonaws.com"
             registry="${registry_host}/<< pipeline.parameters.project_name >>"
             tag="${CIRCLE_SHA1:0:7}"
+
+            trap 'docker logout "$registry_host" >/dev/null 2>&1 || true' EXIT
 
             aws ecr get-login-password --region "<< pipeline.parameters.aws_region >>" \
               | docker login --username AWS --password-stdin "$registry_host"
 
             docker tag "<< pipeline.parameters.project_name >>:${tag}" "${registry}:${tag}"
-            docker tag "<< pipeline.parameters.project_name >>:${tag}" "${registry}:latest"
-
             docker push "${registry}:${tag}"
-            docker push "${registry}:latest"
-
-            docker logout "$registry_host"
 
 workflows:
   build_test_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,13 @@
 version: 2.1
 
 executors:
-  custom-executor:
+  # Pinned to the same Node the Dockerfile pins, and to cimg rather than the legacy
+  # circleci/ namespace, which CircleCI deprecated. The old executor was
+  # circleci/node:lts-browsers: a moving tag (so the Node under CI drifted with no
+  # commit) carrying a headless browser this project has no use for.
+  node:
     docker:
-      - image: circleci/node:lts-browsers
+      - image: cimg/node:14.21.3
 
 parameters:
   project_name:
@@ -15,70 +19,109 @@ parameters:
 
 jobs:
   build:
-    executor: custom-executor
+    executor: node
     steps:
       - checkout
-      - setup_remote_docker
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
+      # npm ci, not npm install. npm install may resolve past the lockfile; npm ci
+      # installs exactly what it pins and fails if the manifest and lock disagree.
       - run:
-          name: Installing local dependencies
-          command: npm install
+          name: Install dependencies
+          command: npm ci
       - save_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
+      # node_modules only. The old config also persisted `src`, which does not exist in
+      # this repo (every source file is at the root), and the downstream jobs only
+      # appeared to work because `checkout` had already put the sources there.
       - persist_to_workspace:
-          root: /home/circleci/project
+          root: .
           paths:
-            - src
             - node_modules
 
   lint:
-    executor: custom-executor
+    executor: node
     steps:
       - checkout
       - attach_workspace:
-          at: /home/circleci/project
+          at: .
       - run:
           name: Lint
           command: npm run lint
 
+  # The workflow was already called build_test_deploy and had no test job.
+  test:
+    executor: node
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Test
+          command: npm test
+
   push:
-    executor: custom-executor
+    executor: node
     steps:
       - checkout
       - setup_remote_docker
-      - attach_workspace:
-          at: /home/circleci/project
+      # cimg/node ships no AWS CLI. The old config ran `sudo apt-get install awscli`
+      # with no apt-get update first, and Ubuntu's package is AWS CLI v1, which is the
+      # only reason `aws ecr get-login` below worked at all.
       - run:
-          name: Build docker image with NO cache
-          command: docker build --no-cache -t << pipeline.parameters.project_name >>:latest .
-      - run:
-          name: Tag the docker image
-          command: docker tag << pipeline.parameters.project_name >>:latest $AWS_ACCOUNT.dkr.ecr.<< pipeline.parameters.aws_region >>.amazonaws.com/<< pipeline.parameters.project_name >>:latest
-      - run:
-          name: Install AWS cli
-          command: sudo apt-get install awscli
-      - run:
-          name: Push image to ECR
+          name: Install the AWS CLI
           command: |
+            curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+            unzip -q /tmp/awscliv2.zip -d /tmp
+            sudo /tmp/aws/install
             aws --version
-            eval $(aws ecr get-login --region << pipeline.parameters.aws_region >>| sed 's/ \-e none//')
-            # newer versions eval $(aws ecr get-login --region << pipeline.parameters.aws_region >> --no-include-email)
-            docker push $AWS_ACCOUNT.dkr.ecr.<< pipeline.parameters.aws_region >>.amazonaws.com/<< pipeline.parameters.project_name >>:latest
+      - run:
+          name: Build the image
+          command: |
+            docker build -t "<< pipeline.parameters.project_name >>:${CIRCLE_SHA1:0:7}" .
+      # get-login-password piped into --password-stdin. The old step was
+      # `eval $(aws ecr get-login ... | sed 's/ \-e none//')`, which builds a
+      # `docker login -p <token>` command: the token lands in the process list and in
+      # the build log. `get-login` was also removed in AWS CLI v2.
+      #
+      # AWS_ACCOUNT_ID, AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY come from the
+      # project's environment variables. CircleCI has no instance metadata, so unlike
+      # the Jenkins pipeline this one does need a key; scope its IAM policy to ECR push
+      # on this one repository, as the README shows.
+      - run:
+          name: Push to ECR
+          command: |
+            registry_host="${AWS_ACCOUNT_ID}.dkr.ecr.<< pipeline.parameters.aws_region >>.amazonaws.com"
+            registry="${registry_host}/<< pipeline.parameters.project_name >>"
+            tag="${CIRCLE_SHA1:0:7}"
+
+            aws ecr get-login-password --region "<< pipeline.parameters.aws_region >>" \
+              | docker login --username AWS --password-stdin "$registry_host"
+
+            docker tag "<< pipeline.parameters.project_name >>:${tag}" "${registry}:${tag}"
+            docker tag "<< pipeline.parameters.project_name >>:${tag}" "${registry}:latest"
+
+            docker push "${registry}:${tag}"
+            docker push "${registry}:latest"
+
+            docker logout "$registry_host"
 
 workflows:
-  version: 2
   build_test_deploy:
     jobs:
       - build
       - lint:
           requires:
             - build
+      - test:
+          requires:
+            - build
       - push:
           requires:
             - lint
+            - test
           filters:
             branches:
               only: master

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,40 @@
+# The Dockerfile copies named files rather than `COPY . .`, so this list is defence in
+# depth rather than the only thing standing between the repository and the image. It is
+# still worth having: `docker build` sends the whole context to the daemon before the
+# first instruction runs, so anything not excluded here is transferred either way.
+
+# Git history. This was the real hole in the old two-line version: .git was 164K of
+# full history inside an image being pushed to a registry.
+.git
+.gitignore
+
+# Installed inside the image from the lockfile, and a host node_modules would be the
+# wrong platform anyway.
 node_modules
-npm-debug.log
+npm-debug.log*
+yarn-error.log*
+logs
+*.log
+
+# Build and CI configuration. None of it is needed at runtime and the Jenkinsfile names
+# an account and a region.
+Dockerfile
+.dockerignore
+Jenkinsfile
+.circleci
+.eslintrc.js
+
+# Docs and tests
+README.md
+LICENSE
+test
+
+# Local environment and anything that looks like a credential
+.env
+.env.*
+*.pem
+*.key
+credentials*
+secrets
+
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,21 @@ node_modules/
 
 # env
 .env
+.env.*
+
+# Keys and credentials. The Jenkins walkthrough in the README has you SSH with a .pem,
+# and the working directory people run that from is often the clone.
+*.pem
+*.key
+credentials*
+secrets/
+
+# Local databases
+*.sqlite
+*.db
+
+# Python, for the odd helper script
+__pycache__/
+
+# macOS
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,49 @@
-FROM node:latest
+# Pinned, and pinned to the Node this project was written for. `node:latest` today
+# resolves to Node 26, twelve major versions past the 14 that the Jenkins NodeJS tool
+# in the README configures, and it changes under you without a commit. The alpine
+# variant is the same Node 14.21.3 and npm 6.14.18 in a much smaller image.
+FROM node:14.21.3-alpine
 
-# Metadata for the image
 LABEL app="express-app"
-# Set env variables key to value pair
-ENV NPM_CONFIG_LOGLEVEL warn
 
-# The app dir
+# `ENV key value` is the legacy form and Docker now warns about it (LegacyKeyValueFormat).
+# PORT and HOST are read by constants.js, so the port lives in exactly one place and
+# EXPOSE and the HEALTHCHECK below both follow it.
+ENV NPM_CONFIG_LOGLEVEL=warn \
+    NODE_ENV=production \
+    PORT=8080 \
+    HOST=0.0.0.0
+
 WORKDIR /app
 
-# Install dependencies
-# * will refer to both, package and package-lock 
-COPY package*.json ./
+# The manifest and the lockfile on their own layer, before the source, so that editing
+# server.js does not invalidate the install layer.
+COPY package.json package-lock.json ./
 
-RUN npm install --production
+# `npm ci`, not `npm install`. There is a lockfile right here and `npm install` is free
+# to ignore it and resolve something newer; `npm ci` installs exactly what it pins and
+# fails if the two disagree. --only=production is npm 6 syntax (npm 7 renamed it
+# --omit=dev) and this image ships npm 6.14.18.
+RUN npm ci --only=production && npm cache clean --force
 
-# Bundle app source
-COPY . .
+# Named files rather than `COPY . .`. With the old two-line .dockerignore, `COPY . .`
+# shipped .git (the whole history), the Jenkinsfile, the CircleCI config and the README
+# into a public image. .dockerignore is fixed too, but an explicit list cannot be
+# defeated by forgetting to add an entry to it later.
+COPY app.js server.js constants.js ./
+
+# The image already ships an unprivileged `node` user (uid 1000). Nothing here needs
+# root, and the app writes nothing to disk at all.
+USER node
 
 EXPOSE 8080
-CMD [ "npm", "start" ]
+
+# wget is busybox's, already in the alpine image, so this costs no extra layer. Shell
+# form on purpose: ${PORT} has to be expanded at runtime.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget -q -O /dev/null "http://127.0.0.1:${PORT}/healthz" || exit 1
+
+# Exec form, so node is PID 1 and receives SIGTERM directly. server.js handles it; see
+# the measurements in the comment there for why the handler, not this line, is the part
+# that makes `docker stop` fast.
+CMD ["node", "server.js"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,54 +1,98 @@
 pipeline {
   agent any
 
-  environment {
-    registry = 'your-aws-account.dkr.ecr.us-east-1.amazonaws.com/web-app:latest'
+  // None of this was here, and all four matter on a t2/t3 instance with an 8 GiB root
+  // volume. disableConcurrentBuilds is the load-bearing one: two runs of the old
+  // pipeline both built web-app:latest and both pushed :latest, so whichever finished
+  // second won and the tag no longer told you which commit was in the registry.
+  options {
+    timeout(time: 20, unit: 'MINUTES')
+    buildDiscarder(logRotator(numToKeepStr: '20'))
+    disableConcurrentBuilds()
+    timestamps()
   }
 
-  tools {nodejs "node"}
+  environment {
+    AWS_REGION = 'us-east-1'
+    // Replace with your account ID. The ECR repository name is the last path segment.
+    ECR_ACCOUNT = '123456789012'
+    IMAGE_NAME = 'web-app'
+    REGISTRY_HOST = "${ECR_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+    REGISTRY = "${ECR_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/${IMAGE_NAME}"
+  }
+
+  tools { nodejs 'node' }
 
   stages {
 
-    stage('Build') {
+    stage('Install') {
       steps {
-        sh 'npm install'
+        // npm ci, not npm install: there is a lockfile and this is CI, which is the
+        // exact case npm ci exists for.
+        sh 'npm ci'
       }
     }
 
-    stage('Lint JS') {
+    stage('Lint') {
       steps {
         sh 'npm run lint'
       }
     }
 
-    stage('Build Docker Image') {
+    // The old pipeline had no test stage, and no tests to run in one.
+    stage('Test') {
       steps {
-        sh 'docker build --no-cache -t web-app:latest .'
-	  }
-	}
-
-    stage('Tag Docker Image') {
-      steps {
-        sh 'docker tag web-app:latest ${registry}'
-	  }
-	}
-
-    stage('AWS Login') {
-      steps {
-        withAWS(credentials:'MyAWSCredentials', , region: 'us-east-1') {
-            script {
-                def login = ecrLogin()
-                sh "${login}"
-            }
-        }
+        sh 'npm test'
       }
     }
 
-    stage('Push') {
+    stage('Build image') {
       steps {
-        sh 'docker push ${registry}'
-	  }
-	}
+        // Tag with the short commit SHA as well as latest, so the registry records
+        // which commit is deployed and a rollback is possible. Read from git rather
+        // than env.GIT_COMMIT, which is unset outside a multibranch/SCM job.
+        script {
+          env.IMAGE_TAG = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
+        }
+        sh 'docker build -t "$IMAGE_NAME:$IMAGE_TAG" .'
+      }
+    }
 
+    stage('Push to ECR') {
+      // Blue Ocean's GitHub flow creates a multibranch job, so BRANCH_NAME is set. A
+      // plain single-branch Pipeline job leaves it unset and this stage is skipped,
+      // which is the safe direction to fail.
+      when { branch 'master' }
+      steps {
+        // No credentials: block, and no AWS credential stored in Jenkins at all. The
+        // instance carries an IAM role, so the CLI picks up short-lived rotated
+        // credentials from instance metadata. See the README for the policy.
+        //
+        // get-login-password piped into --password-stdin, rather than the Amazon ECR
+        // plugin's ecrLogin() or `aws ecr get-login`. Jenkins runs sh steps with -x, so
+        // any command that takes the token as an argument prints the token into the
+        // build log. Piped on stdin it never appears in an argument list.
+        sh '''
+          aws ecr get-login-password --region "$AWS_REGION" \
+            | docker login --username AWS --password-stdin "$REGISTRY_HOST"
+
+          docker tag "$IMAGE_NAME:$IMAGE_TAG" "$REGISTRY:$IMAGE_TAG"
+          docker tag "$IMAGE_NAME:$IMAGE_TAG" "$REGISTRY:latest"
+
+          docker push "$REGISTRY:$IMAGE_TAG"
+          docker push "$REGISTRY:latest"
+        '''
+      }
+    }
+  }
+
+  post {
+    always {
+      // The login writes credentials into ~/.docker/config.json on the agent, so log
+      // out even when a stage failed. || true because logout is an error if the push
+      // stage never logged in.
+      sh 'docker logout "$REGISTRY_HOST" || true'
+      cleanWs()
+    }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,11 +14,7 @@ pipeline {
 
   environment {
     AWS_REGION = 'us-east-1'
-    // Replace with your account ID. The ECR repository name is the last path segment.
-    ECR_ACCOUNT = '123456789012'
     IMAGE_NAME = 'web-app'
-    REGISTRY_HOST = "${ECR_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com"
-    REGISTRY = "${ECR_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/${IMAGE_NAME}"
   }
 
   tools { nodejs 'node' }
@@ -68,19 +64,33 @@ pipeline {
         // instance carries an IAM role, so the CLI picks up short-lived rotated
         // credentials from instance metadata. See the README for the policy.
         //
+        // The account ID is read from STS rather than committed. A placeholder in this
+        // file is a thing to forget: leave it unedited and the pipeline authenticates
+        // against, and pushes to, whatever account 123456789012 is. Asking STS also
+        // fails immediately and legibly when no role is attached.
+        //
         // get-login-password piped into --password-stdin, rather than the Amazon ECR
         // plugin's ecrLogin() or `aws ecr get-login`. Jenkins runs sh steps with -x, so
         // any command that takes the token as an argument prints the token into the
         // build log. Piped on stdin it never appears in an argument list.
         sh '''
+          account=$(aws sts get-caller-identity --query Account --output text)
+          registry_host="${account}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+          registry="${registry_host}/${IMAGE_NAME}"
+
+          # Log out however this block exits, so the credential does not survive in the
+          # agent's ~/.docker/config.json after a failed push. Jenkins runs sh with -e,
+          # so without a trap an error between login and the end skips the cleanup.
+          trap 'docker logout "$registry_host" >/dev/null 2>&1 || true' EXIT
+
           aws ecr get-login-password --region "$AWS_REGION" \
-            | docker login --username AWS --password-stdin "$REGISTRY_HOST"
+            | docker login --username AWS --password-stdin "$registry_host"
 
-          docker tag "$IMAGE_NAME:$IMAGE_TAG" "$REGISTRY:$IMAGE_TAG"
-          docker tag "$IMAGE_NAME:$IMAGE_TAG" "$REGISTRY:latest"
+          docker tag "$IMAGE_NAME:$IMAGE_TAG" "$registry:$IMAGE_TAG"
+          docker tag "$IMAGE_NAME:$IMAGE_TAG" "$registry:latest"
 
-          docker push "$REGISTRY:$IMAGE_TAG"
-          docker push "$REGISTRY:latest"
+          docker push "$registry:$IMAGE_TAG"
+          docker push "$registry:latest"
         '''
       }
     }
@@ -88,10 +98,8 @@ pipeline {
 
   post {
     always {
-      // The login writes credentials into ~/.docker/config.json on the agent, so log
-      // out even when a stage failed. || true because logout is an error if the push
-      // stage never logged in.
-      sh 'docker logout "$REGISTRY_HOST" || true'
+      // The logout lives in the push stage's own trap, next to the registry host it
+      // needs, rather than here where the value would have to be recomputed.
       cleanWs()
     }
   }

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Docker App
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,22 @@ produces an image you would be willing to run, and **two** pipelines that build 
 image and push it to Amazon ECR, one in Jenkins and one in CircleCI, so you can compare
 them on the same job.
 
-Originally written in **April 2020**. The app is unchanged in behaviour and the
-dependency versions are deliberately frozen there. The infrastructure walkthrough is not
+Originally written in **April 2020**, and the dependency versions are deliberately
+frozen there. The app's existing route is unchanged: `/` still answers
+`It is working!`. What did change is a new `/healthz` for the container health check,
+plus startup and shutdown behaviour, both covered below. The infrastructure walkthrough is not
 frozen: the AWS console, Jenkins' installation procedure and the AWS CLI have all moved,
 so the commands below are the ones that work today, and where something changed
 materially it is called out.
+
+**Node 14 is end of life**, since 2023-04-30 per the [Node.js release
+schedule](https://github.com/nodejs/Release/blob/main/schedule.json), and it gets no
+security fixes. It is pinned here on purpose: this repository exists to be the 2020
+project done properly, and moving the runtime would mean moving `express`, the lockfile
+and the CI images with it, which is a different exercise. Treat the image as a teaching
+artifact, not a production runtime. If you want to run something like it for real, bump
+the base image, `engines`, the CircleCI executor and the Jenkins NodeJS tool together,
+and expect `npm ci` to want a regenerated lockfile.
 
 ## The app
 
@@ -19,7 +30,7 @@ materially it is called out.
 | --- | --- |
 | `app.js` | the Express app, two routes, exports it and binds nothing |
 | `server.js` | binds the port, handles a failed bind, handles SIGTERM |
-| `constants.js` | `PORT` and `HOST` from the environment, with defaults |
+| `constants.js` | `PORT` and `HOST` from the environment, validated, with defaults |
 | `test/smoke.js` | mounts `app.js` on an ephemeral port and asserts against it |
 
 `app.js` and `server.js` used to be one file, and that is why there were no tests:
@@ -127,6 +138,24 @@ and exited 1. The README's own "check what we are logging" step used that exact 
 proof the container was working. The message is in the `listen` callback now, and there is
 an `error` handler that says what went wrong in one line.
 
+That error handler has a gap it cannot cover, which is why `constants.js` validates
+`PORT` rather than coercing it. `net.Server#listen` rejects a bad port by throwing
+**synchronously**, inside the `app.listen` call, before the `server.on('error')` line
+below it has run. So the handler never sees it. `Number(process.env.PORT) || 8080` accepts
+anything truthy, and all four of these threw:
+
+| `PORT` | coerced to | result |
+| --- | --- | --- |
+| `99999` | `99999` | `RangeError: options.port should be >= 0 and < 65536` |
+| `Infinity` | `Infinity` | `RangeError` |
+| `8080.5` | `8080.5` | `RangeError` |
+| `-1` | `-1` | `RangeError` |
+
+`constants.js` now requires an integer in 1 to 65535 and throws with a message naming the
+variable. Unset or empty still falls back to 8080; set-but-invalid fails loudly, because
+silently falling back would turn a typo in a deployment config into a service quietly
+listening on the wrong port.
+
 ## Amazon ECR
 
 ```shell
@@ -166,6 +195,13 @@ that cannot be scoped to a resource, because it does not act on one:
   ]
 }
 ```
+
+**The region in that ARN is part of the grant.** An ECR repository ARN names a region, so
+this policy authorizes `us-east-1` and nothing else. The `Jenkinsfile` has
+`AWS_REGION = 'us-east-1'` and the CircleCI config takes an `aws_region` parameter that
+defaults to the same, so out of the box they agree. Change either one without changing the
+ARN and the push fails on authorization rather than on anything that names the region, so
+it is worth keeping the three in step deliberately.
 
 The old README attached nothing in particular and had you paste an access key, so in
 practice the pipeline ran with whatever the key's owner could do.
@@ -232,7 +268,7 @@ Credentials**.
 ssh -i ~/.ssh/JenkinsKP.pem ubuntu@YOUR-EC2-PUBLIC-IP-OR-DNS
 
 sudo apt-get update
-sudo apt-get install -y fontconfig openjdk-21-jre
+sudo apt-get install -y fontconfig openjdk-21-jre unzip
 
 sudo mkdir -p /etc/apt/keyrings
 sudo wget -O /etc/apt/keyrings/jenkins-keyring.asc \
@@ -248,7 +284,7 @@ sudo apt-get install -y jenkins
 **On Amazon Linux 2023:**
 
 ```shell
-sudo dnf install -y java-21-amazon-corretto-headless git
+sudo dnf install -y java-21-amazon-corretto-headless git unzip
 
 sudo curl -fsSL -o /etc/yum.repos.d/jenkins.repo \
   https://pkg.jenkins.io/redhat-stable/jenkins.repo
@@ -258,7 +294,7 @@ sudo dnf install -y jenkins
 sudo systemctl enable --now jenkins
 ```
 
-Both resolve Jenkins **2.568.2** as of writing. The old instructions do not, and it is
+Both resolved Jenkins **2.568.2** when this was tested. The commands are unpinned, so you will get whatever the repository's current candidate is. The old instructions do not, and it is
 worth being precise about why, because most of the URLs still work:
 
 - **The signing key no longer matches the repository.** The old steps fetched
@@ -284,27 +320,65 @@ Ubuntu walkthrough, and an uninstall section in `yum` after installing with `apt
 are the two paths above now, each complete.
 
 **Docker.** The old section never actually installed it: it ended at `apt-cache policy
-docker-ce`, which only queries. Use Docker's own script, and put the Jenkins user in the
-`docker` group so the pipeline's `docker build` works without sudo:
+docker-ce`, which only queries. Install from Docker's signed apt repository, the same
+`signed-by` shape as the Jenkins repository above:
 
 ```shell
-curl -fsSL https://get.docker.com | sudo sh
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+  -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+. /etc/os-release
+echo "deb [arch=$(dpkg --print-architecture) \
+  signed-by=/etc/apt/keyrings/docker.asc] \
+  https://download.docker.com/linux/ubuntu ${VERSION_CODENAME} stable" \
+  | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+
 sudo usermod -aG docker jenkins
 sudo systemctl enable --now docker
 sudo systemctl restart jenkins        # the new group only applies to new processes
 ```
 
+Not `curl -fsSL https://get.docker.com | sudo sh`, which is Docker's own convenience
+script but is also an unpinned remote program executed as root, with no signature checked
+before it runs. The repository route verifies every package against a key you installed
+deliberately, and it scopes that key to one repository. `${VERSION_CODENAME}` comes from
+`/etc/os-release` rather than being hardcoded; the old README pinned `bionic`, which is
+wrong on anything newer.
+
 Adding a user to the `docker` group is equivalent to giving it root, since it can
 `docker run -v /:/host`. On a single-purpose Jenkins host that is the trade being made;
 it is not something to do on a shared box.
 
-**AWS CLI**, which the pipeline calls directly:
+**AWS CLI**, which the pipeline calls directly. AWS distributes the installer as a zip
+rather than through a signed repository, so verify its detached signature before running
+anything out of it:
 
 ```shell
 curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip.sig" -o /tmp/awscliv2.sig
+
+# Import the AWS CLI public key, then verify. The key block is published in AWS's own
+# install documentation, which is where to copy it from:
+# https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+gpg --import aws-cli-public-key.asc
+gpg --verify /tmp/awscliv2.sig /tmp/awscliv2.zip     # must say "Good signature"
+
 unzip -q /tmp/awscliv2.zip -d /tmp && sudo /tmp/aws/install
 aws sts get-caller-identity           # should show the instance role
 ```
+
+The key has to come from AWS's documentation rather than from a URL here, because AWS
+publishes it inline in that page and not as a fetchable file: `curl` against the obvious
+`awscli.amazonaws.com/assets/awscli-public-key.asc` returns nothing, so any command in
+this README claiming to fetch it would be inventing an endpoint. The signature file
+itself is real and does download (566 bytes). Skipping the check entirely means running
+an unpinned remote installer as root, which is the same objection as the Docker script
+above.
 
 ### 3. Instance size and disk
 
@@ -385,15 +459,34 @@ argument against the step is the unauthenticated socket and the wrong port, not 
 `.circleci/config.yml`, same job in a different shape: `build`, then `lint` and `test` in
 parallel, then `push` on `master` only.
 
-CircleCI has no instance metadata, so this is the one place a long-lived key is
-unavoidable. Set these as project environment variables, with the key scoped to exactly
-the ECR policy above and nothing else:
+CircleCI has no instance metadata, so unlike the Jenkins pipeline it cannot use a role
+attached to the machine. Set these as project environment variables, with the key scoped
+to exactly the ECR policy above and nothing else:
 
 | Variable | Value |
 | --- | --- |
-| `AWS_ACCOUNT_ID` | your account ID |
 | `AWS_ACCESS_KEY_ID` | the CI user's key |
 | `AWS_SECRET_ACCESS_KEY` | the CI user's secret |
+
+No `AWS_ACCOUNT_ID`: the job asks STS for the account, so there is one fewer variable and
+no way for it to disagree with the key.
+
+**A static key is not the current answer, only the period-accurate one.** CircleCI Cloud
+supports OIDC now, so the modern shape is an IAM role trusted for
+`sts:AssumeRoleWithWebIdentity` from your CircleCI organization, with the job exchanging a
+short-lived token for credentials and no secret stored in the project at all. That arrived
+well after this repository's era, which is why the config here does not use it. If you keep
+the static key, treat it as a credential with a lifecycle: give it only the ECR policy
+above, rotate it on a schedule, and check CloudTrail for its use, because unlike the
+instance role it does not expire on its own.
+
+**Only the SHA tag is pushed here, where the Jenkins pipeline also moves `:latest`.** That
+asymmetry is deliberate. Jenkins has `disableConcurrentBuilds()`; CircleCI has no
+equivalent, so two `master` workflows can be in the push job at once, and if the older one
+finishes last it leaves `:latest` pointing at the earlier commit while both SHA tags stay
+correct. A mutable tag that can silently move backwards is worse than no mutable tag, so
+promotion of `:latest` belongs to the serialized pipeline or to a deliberate step of its
+own. Deploy by the SHA tag either way.
 
 Four things changed from the 2020 config:
 

--- a/README.md
+++ b/README.md
@@ -370,8 +370,15 @@ The **Docker Host URI** step, `tcp://172.17.0.40:2345` under *Manage Jenkins →
 unauthenticated, unencrypted Docker daemon socket is root on the host to anyone who can
 reach the port, and this pipeline never needed it: `docker build`, `docker tag` and
 `docker push` all run through the local CLI on the agent. It could not have worked as
-written either, since Docker listens on 2375 (plain) or 2376 (TLS), and `172.17.0.40` is a
-docker0 bridge address rather than anything reachable.
+written either: Docker's TCP socket is 2375 (plain) or 2376 (TLS), never 2345, and the
+daemon does not listen on TCP at all unless you configure it to.
+
+The address is worth a caveat rather than a flat claim. `172.17.0.0/16` is Docker's
+documented default for the `docker0` bridge, so `172.17.0.40` looks like a container
+address, which is not a thing to point a cloud configuration at. That default is not
+universal, though: on the machine these commands were checked on, Docker hands the default
+bridge `192.168.215.0/24` and a container came up on `192.168.215.2`. Either way the
+argument against the step is the unauthenticated socket and the wrong port, not the subnet.
 
 ## CircleCI
 

--- a/README.md
+++ b/README.md
@@ -1,246 +1,417 @@
 # Docker App
-Simple `Express App` 
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
+
+A three-file Express app whose point is everything around it: a `Dockerfile` that
+produces an image you would be willing to run, and **two** pipelines that build that
+image and push it to Amazon ECR, one in Jenkins and one in CircleCI, so you can compare
+them on the same job.
+
+Originally written in **April 2020**. The app is unchanged in behaviour and the
+dependency versions are deliberately frozen there. The infrastructure walkthrough is not
+frozen: the AWS console, Jenkins' installation procedure and the AWS CLI have all moved,
+so the commands below are the ones that work today, and where something changed
+materially it is called out.
+
+## The app
+
+| File | Role |
+| --- | --- |
+| `app.js` | the Express app, two routes, exports it and binds nothing |
+| `server.js` | binds the port, handles a failed bind, handles SIGTERM |
+| `constants.js` | `PORT` and `HOST` from the environment, with defaults |
+| `test/smoke.js` | mounts `app.js` on an ephemeral port and asserts against it |
+
+`app.js` and `server.js` used to be one file, and that is why there were no tests:
+`require('./server')` took port 8080 as a side effect of the import, so nothing could
+mount the app twice or on a port of its own choosing.
+
+```shell
+npm ci          # not npm install: there is a lockfile, at lockfileVersion 1
+npm start
+npm test
+npm run lint
+```
+
+```shell
+curl -i http://localhost:8080/
+curl -s http://localhost:8080/healthz
+```
+
+`/healthz` exists for the container health check, so that a probe and a real request are
+distinguishable in the logs.
+
+## Building and running the image
+
+```shell
+docker build -t web-app:latest .
+docker run -d -p 8080:8080 --name web-app web-app:latest
+
+docker ps                       # STATUS shows (healthy) after a few seconds
+docker logs web-app             # Running on http://0.0.0.0:8080
+curl -s http://localhost:8080/  # It is working!
+
+docker stop web-app && docker rm web-app
+```
+
+### What the Dockerfile does, and why each line is there
+
+**`FROM node:14.21.3-alpine`, not `node:latest`.** `latest` is a moving tag: it resolves
+to **Node 26.7.0** as of writing, twelve major versions past the Node 14 that this
+project targets and that the Jenkins NodeJS tool below configures. The version your image
+runs then changes without a commit, which is the opposite of what an image is for. Pinning
+to alpine also takes the image from **1.27 GB to 120 MB**, measured on the two builds, and
+the base ships the same npm 6.14.18.
+
+**`npm ci --only=production`, not `npm install --production`.** There is a
+`package-lock.json` in the build context. `npm install` is allowed to resolve past it;
+`npm ci` installs exactly what it pins and fails if the lockfile and the manifest
+disagree. `--only=production` is npm 6 syntax, which is what this base image has (npm 7
+renamed it to `--omit=dev`).
+
+**`USER node`.** The container used to run as root, verified with `docker run --rm
+web-app id` returning `uid=0(root)`. The official Node images already ship an
+unprivileged `node` user at uid 1000, and nothing here needs more.
+
+**Named `COPY`, and a real `.dockerignore`.** The old `.dockerignore` had two entries,
+`node_modules` and `npm-debug.log`, so `COPY . .` shipped `.git` (164K of full history),
+the `Jenkinsfile`, the CircleCI config and the README into an image being pushed to a
+registry. Both are fixed: the Dockerfile copies the three source files by name, and
+`.dockerignore` is a full list as defence in depth. Note that `docker build` transfers
+the entire context to the daemon before the first instruction runs, so `.dockerignore`
+earns its place either way.
+
+**`HEALTHCHECK`.** busybox `wget` is already in the alpine image, so the check costs
+nothing extra. It hits `/healthz` at the port `constants.js` reads, which is why `PORT`
+is an `ENV` rather than a literal repeated in three files.
+
+### Signals, which is the interesting part
+
+`docker stop` sends SIGTERM and waits ten seconds before SIGKILL. A process running as
+**PID 1 gets no default signal dispositions from the kernel**, so a SIGTERM it does not
+explicitly handle is discarded. Measured on `node:14` with `docker stop`:
+
+| CMD | stop time | exit code |
+| --- | --- | --- |
+| `["npm", "start"]` (what this repo used to do) | 0.15s | 0 |
+| `["node", "server.js"]`, no signal handler | **10.24s** | **137** (SIGKILL) |
+| `["node", "server.js"]` + `docker run --init` | 0.19s | 143 |
+| `["node", "server.js"]` + an explicit handler | 0.17s | 0 |
+
+So the common advice, "do not use `npm start` as your CMD, call node directly", makes
+things **strictly worse** on its own: npm was the thing catching the signal. The handler
+in `server.js` is what matters, and the CMD change just removes a process from the
+middle. `server.close()` also drains in-flight responses, which is the difference between
+a deploy that drops requests and one that does not.
+
+`npm start` is not free of surprises either. On npm 11 the same container stops in 0.67s
+but exits **1**, which an orchestrator reads as a crash rather than a clean stop.
+
+### The other bug worth knowing
+
+`server.js` used to log success it did not have:
+
+```js
+app.listen(PORT, HOST);
+console.log(`Running on http://${HOST}:${PORT}`);
+```
+
+`app.listen` is asynchronous, so with port 8080 already taken the container printed
+
+```text
+Running on http://0.0.0.0:8080
+events.js:377 ... EADDRINUSE
+```
+
+and exited 1. The README's own "check what we are logging" step used that exact line as
+proof the container was working. The message is in the `listen` callback now, and there is
+an `error` handler that says what went wrong in one line.
+
+## Amazon ECR
+
+```shell
+aws ecr create-repository --repository-name web-app
+aws ecr describe-repositories --repository-name web-app   # for the URI
+```
+
+Your registry URI is `<account-id>.dkr.ecr.<region>.amazonaws.com/web-app`.
+
+### The IAM policy, which the old walkthrough did not have
+
+Pushing an image needs six actions and no more. `ecr:GetAuthorizationToken` is the one
+that cannot be scoped to a resource, because it does not act on one:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EcrAuthToken",
+      "Effect": "Allow",
+      "Action": "ecr:GetAuthorizationToken",
+      "Resource": "*"
+    },
+    {
+      "Sid": "PushWebApp",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:PutImage"
+      ],
+      "Resource": "arn:aws:ecr:us-east-1:123456789012:repository/web-app"
+    }
+  ]
+}
+```
+
+The old README attached nothing in particular and had you paste an access key, so in
+practice the pipeline ran with whatever the key's owner could do.
+
+### Logging in and pushing by hand
+
+```shell
+account=$(aws sts get-caller-identity --query Account --output text)
+registry_host="${account}.dkr.ecr.us-east-1.amazonaws.com"
+
+aws ecr get-login-password --region us-east-1 \
+  | docker login --username AWS --password-stdin "$registry_host"
+
+tag=$(git rev-parse --short HEAD)
+docker build -t "web-app:${tag}" .
+docker tag "web-app:${tag}" "${registry_host}/web-app:${tag}"
+docker tag "web-app:${tag}" "${registry_host}/web-app:latest"
+docker push "${registry_host}/web-app:${tag}"
+docker push "${registry_host}/web-app:latest"
+
+docker logout "$registry_host"
+```
+
+Two things changed here since 2020. **`aws ecr get-login` is gone** in AWS CLI v2, and it
+was worth removing: it printed a `docker login -p <token>` command that you then
+`eval`'d, so the token landed in your shell history, in the process list, and in any CI
+log with command echoing on. `get-login-password` piped into `--password-stdin` never puts
+it in an argument.
+
+**The image is tagged with the commit SHA as well as `latest`.** Everything used to be
+`:latest` only, which means the registry cannot tell you what is deployed and there is
+nothing to roll back to.
 
 ## Jenkins
 
-- Launch an Ubuntu (t2.micro) EC2 instance.
-- In the Security Group, Inbound, allow...
-  - Port 22 (SSH) for Your IP
-  - Port 8080 (Jenkins) for Your Ip
-- Install JAVA Development Kit and Jenkins
+The pipeline is `Jenkinsfile`. Five stages: install, lint, test, build the image, and push
+to ECR on `master` only.
+
+### 1. An instance role, not an access key
+
+The old walkthrough had you paste an AWS access key and secret into Jenkins, in two
+separate places (once as *AWS Credentials*, then again at the very end under *Configure
+CloudBees Credentials*, with the same ID). Jenkins here runs on EC2, which means it can
+carry an **IAM role** and the AWS SDK will read short-lived, automatically rotated
+credentials from instance metadata. There is then no long-lived secret to leak, rotate, or
+paste into a screenshot, on a box whose entire job is running arbitrary shell.
+
+Create a role with trusted entity **AWS service, EC2**, attach the ECR policy above, and
+attach the role to the instance under **EC2 → Instances → Actions → Security → Modify IAM
+role**. It takes effect immediately, with no restart.
+
+The `Jenkinsfile` therefore stores no credential and names none. `aws ecr
+get-login-password` finds the role through the default credential chain.
+
+If you run Jenkins somewhere without instance metadata, that is the case where you do
+need a key. Scope it to exactly the policy above and store it under **Manage Jenkins →
+Credentials**.
+
+### 2. Install Jenkins, Docker and the AWS CLI
+
+**On Ubuntu:**
 
 ```shell
-ssh -i "JenkinsKP.pem" ubuntu@YOUR-EC2-PUBLIC-IP-OR-DNS
+ssh -i ~/.ssh/JenkinsKP.pem ubuntu@YOUR-EC2-PUBLIC-IP-OR-DNS
+
 sudo apt-get update
-sudo apt install -y default-jdk
-wget -q -O - https://pkg.jenkins.io/debian/jenkins.io.key | sudo apt-key add -
-#sudo sh -c 'echo deb https://pkg.jenkins.io/debian-stable binary/ > /etc/apt/sources.list.d/jenkins.list'
-sudo sh -c 'echo deb http://pkg.jenkins-ci.org/debian binary/ > /etc/apt/sources.list.d/jenkins.list'
+sudo apt-get install -y fontconfig openjdk-21-jre
+
+sudo mkdir -p /etc/apt/keyrings
+sudo wget -O /etc/apt/keyrings/jenkins-keyring.asc \
+  https://pkg.jenkins.io/debian-stable/jenkins.io-2026.key
+echo "deb [signed-by=/etc/apt/keyrings/jenkins-keyring.asc] \
+  https://pkg.jenkins.io/debian-stable binary/" \
+  | sudo tee /etc/apt/sources.list.d/jenkins.list > /dev/null
+
 sudo apt-get update
 sudo apt-get install -y jenkins
 ```
 
-```shell
-sudo su
-yum update
-
-yum install git
-
-yum list "java-*-openjdk-devel"
-
-yum install java-1.8.0-openjdk-devel.x86_64 
-
-sudo wget -O /etc/yum.repos.d/jenkins.repo http://pkg.jenkins-ci.org/redhat-stable/jenkins.repo
-
-sudo rpm --import https://jenkins-ci.org/redhat/jenkins-ci.org.key
-
-sudo yum install jenkins
-
-sudo service jenkins start # or systemctl enable jenkins
-```
-
-- Go to YOUR-EC2-PUBLIC-IP-OR-DNS:8080/
-- Paste the code you will obtain as the result of executing `sudo cat /var/lib/jenkins/secrets/initialAdminPassword` in your EC2
-- This is going to be the password to log into Jenkins. The user, `admin`
-- Install the following plugins (... either through the `UI` or using `Jenkins CLI`)
-
-  - Blue ocean
-  - Common API for Blue Ocean
-  - Config API for Blue Ocean
-  - Dashboard for Blue Ocean
-  - Events API for Blue OceAN
-  - Git Pipeline for Blue Ocean
-  - GitHub Pipeline for Blue Ocean
-  - Pipeline implementation for Blue Ocean
-  - Blue Ocean pipeline editor
-  - Display URL for Blue Ocean
-  - Blue Ocean Executor info
-  - CloudBees AWS Credentials
-  - Amazon ECR
-  - NodeJS
-
-- Re-start Jenkins: `sudo systemctl restart jenkins`
-
-If you have issues with `git`, go to Manage Jenkins > Global Tool Configuration and set the path to executable. Example: `/bin/git`. You can check the path with `which git`
-
-If you want to uninstall Jenkins
-```
-sudo service jenkins stop
-sudo yum clean all
-sudo yum -y remove jenkins
-sudo rm -rf /var/cache/jenkins
-sudo rm -rf /var/lib/jenkins/
-```
-
-- Re-start Jenkins: `sudo systemctl restart jenkins`
-
-## Docker
+**On Amazon Linux 2023:**
 
 ```shell
-sudo apt update
+sudo dnf install -y java-21-amazon-corretto-headless git
 
-sudo apt install apt-transport-https ca-certificates curl software-properties-common
+sudo curl -fsSL -o /etc/yum.repos.d/jenkins.repo \
+  https://pkg.jenkins.io/redhat-stable/jenkins.repo
+sudo rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2026.key
 
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable"
-
-sudo apt update
-
-apt-cache policy docker-ce
+sudo dnf install -y jenkins
+sudo systemctl enable --now jenkins
 ```
 
-We also need to add `Jenkins` to `docker group`
-```shell
-sudo usermod -a -G docker jenkins
-```
+Both resolve Jenkins **2.568.2** as of writing. The old instructions do not, and it is
+worth being precise about why, because most of the URLs still work:
 
-- Start the daemon
-`sudo service docker start`
+- **The signing key no longer matches the repository.** The old steps fetched
+  `pkg.jenkins.io/debian/jenkins.io.key` and ran `sudo apt-key add -`, which reports `OK`.
+  `apt-get update` then fails with `NO_PUBKEY 7198F4B714ABFC68` and `The repository ... is
+  not signed`, and `apt-get install jenkins` ends at `Package 'jenkins' has no installation
+  candidate`. Jenkins has rotated its signing key since; the current one is the
+  `jenkins.io-2026.key` above.
+- **`apt-key` is deprecated**, and while it is still present on Ubuntu 24.04 it adds the
+  key to the system-wide trusted keyring, so it is trusted for *every* repository rather
+  than just Jenkins'. The `signed-by=` form above scopes it to one.
+- **`default-jdk` is Java 11 on Ubuntu 20.04**, verified as `openjdk version "11.0.27"`,
+  and current Jenkins LTS requires 17 or 21. It happens to be Java 21 on Ubuntu 24.04, so
+  this one fails only on older releases, which is worse than failing everywhere.
+- **`pkg.jenkins-ci.org` is not dead**, it redirects to `pkg.jenkins.io` in three hops, and
+  the `redhat-stable` path now redirects to `rpm-stable`. The old URLs are not the problem.
+- **The old `deb` line pointed at the weekly channel** (`/debian binary/`) while the
+  commented-out line beside it pointed at `debian-stable`. Following it got you weekly
+  builds on a machine you were not going to update.
 
-- Check the service is running
-`sudo service docker status`
+The old README also had an unlabelled second block in `yum` pasted into the middle of the
+Ubuntu walkthrough, and an uninstall section in `yum` after installing with `apt`. Those
+are the two paths above now, each complete.
 
-- We can try to list containers (`docker ps`) and/or images (`docker image ls`), but we should not have any at the moment.
-
-- We are going to download an image from [dockerhub](https://hub.docker.com/) for `node`: https://hub.docker.com/_/node. The official `Node.js` image. 
-  - Pull the image: `docker pull node:latest`
-
-- Now, having the `docker image` we are going to create a `container`: `docker run --name node-container -p 8000:8000 node:latest` 
-
-## Amazon ECR
-We are going to create a repository for our `dockerized app`
-
-- Go to ECR: https://console.aws.amazon.com/ecr/repositories?region=us-east-1
-  - Click on Create repository
-    - Repository name: web-app
-    - Your endpoint will be: your-aws-account-id.dkr.ecr.your-region.amazonaws.com/web-app
-
-- You can also do it using `AWS cli`:
-```shell
-aws ecr create-repository --repository-name web-app
-
-aws ecr describe-repositories --repository-name web-app #to get the repo uri
-```
-
-**IMPORTANT:** Remember that we are building the image, tagging it, logging into ECR and pushing the image to ECR through our `Jenkins pipeline` (Check `application` repo)
-
-
-Yet, you can do the following (aka, manual process)...
+**Docker.** The old section never actually installed it: it ended at `apt-cache policy
+docker-ce`, which only queries. Use Docker's own script, and put the Jenkins user in the
+`docker` group so the pipeline's `docker build` works without sudo:
 
 ```shell
-# Login
-# aws ecr get-login --no-include-email | sh
-# This is preferred over the previous one. And we presuppose your region is us-east-1
-aws ecr get-login-password --region us-east-1 \
-    | docker login \
-        --password-stdin \
-        --username AWS \
-        "$(aws sts get-caller-identity --query Account --output text).dkr.ecr.us-east-1.amazonaws.com"
-
-# Expected result: Login Succeeded
-
-# Build image
-docker build --no-cache -t web-app:latest .
-
-# Tag image
-docker tag web-app:latest your-aws-account-id.dkr.ecr.us-east-1.amazonaws.com/web-app:latest
-
-# Push image
-docker push your-aws-account-id.dkr.ecr.us-east-1.amazonaws.com/web-app:latest
+curl -fsSL https://get.docker.com | sudo sh
+sudo usermod -aG docker jenkins
+sudo systemctl enable --now docker
+sudo systemctl restart jenkins        # the new group only applies to new processes
 ```
 
-### Dockerize App
+Adding a user to the `docker` group is equivalent to giving it root, since it can
+`docker run -v /:/host`. On a single-purpose Jenkins host that is the trade being made;
+it is not something to do on a shared box.
 
-- Create `Dockerfile`
-  We define the image that we are going to pull from `DockerHub`. It will be te same that we are utilizing in the next step: `node:latest`. Then, we create our app directory, install the dependencies, bundle our app source code inside the docker image (`COPY . .`), expose the port to connect and define the command that we will use to run our app (example: `node server.js`)
-- Create `.gitignore` and `.dockerignore`
-- Build the `docker image` (if you don't have the project, clone it: https://github.com/bunchito/application.git): `docker build --no-cache -t web-app .` Be sure docker daemon is running. 
+**AWS CLI**, which the pipeline calls directly:
 
-- Now, if you run `docker images` you should see the `node` and `web-app` docker images
 ```shell
-REPOSITORY                TAG                 IMAGE ID            CREATED             SIZE
-web-app                   latest              f**********d        43 seconds ago      954MB
-node                      latest              e**********2        14 hours ago        943MB
-app                       latest              c**********a        4 weeks ago         1.25GB
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+unzip -q /tmp/awscliv2.zip -d /tmp && sudo /tmp/aws/install
+aws sts get-caller-identity           # should show the instance role
 ```
 
-- Run the image: `docker run -p 8080:8080 -d web-app`
-Note: We can differentiate d from p (flags)
-Example output: `231c***********************************************************9`
+### 3. Instance size and disk
 
-- Now, we can list our `running containers`: `docker ps`
-Example output:
+The original said `t2.micro`, which has **1 GiB of memory**. Jenkins' own hardware
+guidance asks for more than that for anything past a single user, and Java 21 plus Blue
+Ocean is not a light footprint. It will boot and run this pipeline, which is why free-tier
+walkthroughs reach for it, but expect it to be slow and to OOM occasionally during plugin
+installation. `t3.small` (2 GiB) is a more honest floor.
+
+Give it disk too. The console defaults to an **8 GiB root volume**, and this pipeline
+builds Docker images, which is the fastest way to fill one. That is why the `Jenkinsfile`
+sets `buildDiscarder` and calls `cleanWs()`, and it is worth adding a periodic
+`docker image prune`.
+
+Security group inbound: port 22 and port 8080 from **your IP only**, not `0.0.0.0/0`.
+Jenkins on 8080 is unauthenticated until you finish the setup wizard.
+
+### 4. Unlock, and the plugins that are actually needed
+
 ```shell
-CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS               NAMES
-231c********        web-app             "docker-entrypoint.s…"   2 minutes ago       Up 2 minutes        8080/tcp            cranky_driscoll
+sudo cat /var/lib/jenkins/secrets/initialAdminPassword
 ```
 
-- We can check the output of our `application` (aka, what we are logging into the console): `docker logs ********`
-Example output:
-```
-Running on http://0.0.0.0:8080
-```
+Paste it at `http://YOUR-EC2-PUBLIC-IP:8080/`, then create your own admin user.
 
-- Now we can try our `dockerized app`: `curl -i http://localhost:9090`
-Example output:
-```shell
-HTTP/1.1 200 OK
-X-Powered-By: Express
-Content-Type: text/html; charset=utf-8
-Content-Length: 14
-ETag: W/"e-Soux3BO1zgKKRQAaqaQ2kVWUaFc"
-Date: Wed, 22 Apr 2020 00:47:11 GMT
-Connection: keep-alive
+| Plugin | Provides | In *Install suggested plugins*? |
+| --- | --- | --- |
+| **NodeJS** | `tools { nodejs 'node' }` | no, install it |
+| **Blue Ocean** | the pipeline UI, and the GitHub setup flow | no, install it |
+| **Timestamper** | `timestamps()` | **yes** |
+| **Workspace Cleanup** | `cleanWs()` | **yes** |
 
-It is working!
-```
+The last two come with the wizard's suggested set, so most readers already have them and
+never notice. If you chose *Select plugins to install* and took only what a list like this
+named, the build fails before the first stage with `No such DSL method 'timestamps'`, which
+gives no hint that a plugin is the problem.
 
-Optional:
-- If you want to remove the container: `docker rm --force ********`
-- Now, you can make changes to your app and re-build the image: `docker build --no-cache -t web-app .` and then generate a new container: `docker run -p 8080:8080 -d web-app`.
+The old list was the eleven individual `... for Blue Ocean` plugins, which Blue Ocean pulls
+in by itself, plus two that are no longer needed at all: **CloudBees AWS Credentials**,
+because there is no stored credential, and **Amazon ECR**, because the pipeline logs in
+with the AWS CLI rather than the plugin's `ecrLogin()`. That last one is deliberate:
+Jenkins runs `sh` steps with `-x`, so a login command that takes the token as an argument
+prints it into the build log.
 
-### Jenkins pipeline for Docker App
-Every time we make changes yto our source code, we want to re-build the `docker image`
+`timeout()`, `buildDiscarder()` and `disableConcurrentBuilds()` need nothing extra. They
+are core Pipeline.
 
-- Configure `NodeJS` plugin: Manage Jenkins  > Global Tool Configuration 
-  - Click on `Add NodeJS`
-  - Name: `node`
-  - Version: `NodeJS 14.0.0.0`
+Configure the Node version under **Manage Jenkins → Tools → NodeJS → Add NodeJS**, name
+it `node` (the `Jenkinsfile` refers to it by that name) and pick **14.x**, matching the
+Dockerfile's pin.
 
-- Create Jenkins Pipeline 
-  - Open Blue Ocean > Create a new Pipeline
-  - Click on `GitHub`
-  - Go to https://github.com/settings/tokens, generate a token and paste it (you need to be logged-in). For scopes -> repo: all checkboxes, admin repo hook: all checkboxes and user: just read and user email
-  - Select your organization (example, your-GH-username)
-  - Select the repository (example: application)
-  - Create Pipeline
+### 5. Create the pipeline
 
-- Add AWS Credentials to Jenkins
-  - Go to Credentials > Global > Add credentials
-  - Select AWS credentials
-  - Scope: global
-  - Set an ID: MyAWSCredentials
-  - Access Key ID: ****
-  - Secret Access KEY: ****
+Blue Ocean → **New pipeline** → GitHub, authenticate with a token from
+<https://github.com/settings/tokens>, and pick this repository. That creates a multibranch
+job, which is what makes `when { branch 'master' }` on the push stage work.
 
-- Add your ERC URI to to Jenkins Credentials as a `Secret Text`
-  - Scope: global
-  - Secret: your repo URI
-  - ID: web-app-repo
-  - Description: ECR URI web app
+Set `ECR_ACCOUNT` in the `Jenkinsfile`'s `environment` block to your account ID.
 
-- Configure Docker Host URI
-  - Go http://your-ec2-dns:8080/configureClouds/
-  - Select Add a new cloud > Docker
-  - Click on Docker Cloud Details
-  - Docker Host URI: `tcp://172.17.0.40:2345`
-  - Check `Enabled`
-  - Click on `Apply`
-  - Click on `Test Connection`
+### What the old walkthrough had that is now gone
 
-- Configure `CloudBees Credentials`
-  - Go to Credentials > Global > Add credentials
-  - Select AWS credentials
-  - And set an ID: MyAWSCredentials
-  - Access Key ID: ********
-  - Secret Access KEY: ********
+The **Docker Host URI** step, `tcp://172.17.0.40:2345` under *Manage Jenkins → Clouds*. An
+unauthenticated, unencrypted Docker daemon socket is root on the host to anyone who can
+reach the port, and this pipeline never needed it: `docker build`, `docker tag` and
+`docker push` all run through the local CLI on the agent. It could not have worked as
+written either, since Docker listens on 2375 (plain) or 2376 (TLS), and `172.17.0.40` is a
+docker0 bridge address rather than anything reachable.
+
+## CircleCI
+
+`.circleci/config.yml`, same job in a different shape: `build`, then `lint` and `test` in
+parallel, then `push` on `master` only.
+
+CircleCI has no instance metadata, so this is the one place a long-lived key is
+unavoidable. Set these as project environment variables, with the key scoped to exactly
+the ECR policy above and nothing else:
+
+| Variable | Value |
+| --- | --- |
+| `AWS_ACCOUNT_ID` | your account ID |
+| `AWS_ACCESS_KEY_ID` | the CI user's key |
+| `AWS_SECRET_ACCESS_KEY` | the CI user's secret |
+
+Four things changed from the 2020 config:
+
+- **The executor was `circleci/node:lts-browsers`.** A moving tag, so the Node under CI
+  drifted with no commit, in the deprecated `circleci/` namespace, carrying a headless
+  browser this project has no use for. It is `cimg/node:14.21.3` now, matching the
+  Dockerfile.
+- **`persist_to_workspace` persisted `src`**, which does not exist in this repository:
+  every source file is at the root. The downstream jobs only appeared to work because
+  `checkout` had already put the sources there.
+- **There was no test job**, in a workflow named `build_test_deploy`.
+- **`aws ecr get-login`** with a `sed` fixup, `eval`'d, which puts the token in the log.
+  Replaced with `get-login-password --password-stdin`. The old step also ran
+  `sudo apt-get install awscli` with no `apt-get update` first, and Ubuntu's `awscli`
+  package is AWS CLI **v1** (candidate `1.18.69` on 20.04), which is the only reason
+  `get-login` resolved at all: v2 removed it.
+
+## What this walkthrough does not cover
+
+- **Running the image anywhere.** It stops at a tagged image in ECR. ECS, EKS and
+  App Runner all start from there and each is a different walkthrough.
+- **Image scanning.** ECR can scan on push, and for an image pinned to Node 14 it will
+  have plenty to say. The dependency versions here are deliberately frozen at 2020, so
+  scanning is mentioned rather than enabled.
+- **Jenkins behind anything.** It is on 8080, HTTP, reachable from your IP. A real setup
+  puts it behind a reverse proxy with TLS.
+- **Agents.** `agent any` means the controller builds it, which is fine for one image and
+  not how you would run untrusted pipelines.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,22 @@
+// The Express app, and nothing else. Binding a port is server.js's job.
+//
+// This used to be one file, and requiring it started a listener as a side effect,
+// which is why there was no test: `require('./server')` from a test would have taken
+// port 8080 for the duration of the process. Splitting the two means the test can
+// mount the same app on an ephemeral port.
+const express = require('express');
+
+const app = express();
+
+app.get('/', (req, res) => {
+  res.send('It is working!');
+});
+
+// A separate endpoint for the Dockerfile's HEALTHCHECK, so that a health probe and a
+// real request are distinguishable in the logs, and so the check keeps working if `/`
+// ever grows a redirect or an auth guard.
+app.get('/healthz', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+module.exports = app;

--- a/constants.js
+++ b/constants.js
@@ -1,7 +1,40 @@
 // Read from the environment with container-friendly defaults, so the same image can
 // be run on a different port without a rebuild. The Dockerfile sets both, which also
 // means EXPOSE and the HEALTHCHECK no longer repeat a number that lives here.
-const PORT = Number(process.env.PORT) || 8080;
+
+const DEFAULT_PORT = 8080;
+
+// Validated, not just coerced. `Number(process.env.PORT) || 8080` accepts anything
+// truthy, and net.Server#listen then throws a RangeError *synchronously*, which means
+// it happens inside the app.listen call in server.js, before the line below it that
+// registers the error handler. So the handler cannot catch it and the reader gets a
+// stack trace. Measured, all four throwing:
+//
+//   PORT=99999    -> 99999      RangeError: options.port should be >= 0 and < 65536
+//   PORT=Infinity -> Infinity   RangeError (Number.isInteger is false)
+//   PORT=8080.5   -> 8080.5     RangeError
+//   PORT=-1       -> -1         RangeError
+//
+// Unset or empty falls back to the default. Set-but-invalid throws here instead, with
+// a message naming the variable, because silently falling back would turn a typo in a
+// deployment config into a service listening on the wrong port.
+const readPort = (value) => {
+  if (value === undefined || value === '') {
+    return DEFAULT_PORT;
+  }
+
+  const port = Number(value);
+
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new RangeError(
+      `PORT must be an integer between 1 and 65535, received ${JSON.stringify(value)}`
+    );
+  }
+
+  return port;
+};
+
+const PORT = readPort(process.env.PORT);
 
 // 0.0.0.0, not localhost. This is the one line in the project that is genuinely
 // Docker-specific: a server bound to 127.0.0.1 inside a container is reachable only

--- a/constants.js
+++ b/constants.js
@@ -1,9 +1,12 @@
-const PORT = 8080;
+// Read from the environment with container-friendly defaults, so the same image can
+// be run on a different port without a rebuild. The Dockerfile sets both, which also
+// means EXPOSE and the HEALTHCHECK no longer repeat a number that lives here.
+const PORT = Number(process.env.PORT) || 8080;
 
-// This is important for docker 0.0.0.0
-const HOST = '0.0.0.0';
+// 0.0.0.0, not localhost. This is the one line in the project that is genuinely
+// Docker-specific: a server bound to 127.0.0.1 inside a container is reachable only
+// from inside that container, so `docker run -p 8080:8080` publishes a port that
+// nothing is listening on and `curl` from the host gets a connection reset.
+const HOST = process.env.HOST || '0.0.0.0';
 
-module.exports = {
-    PORT,
-    HOST
-}
+module.exports = { PORT, HOST };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "application",
+  "name": "docker-app",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,18 +1,25 @@
 {
-  "name": "application",
+  "name": "docker-app",
   "version": "1.0.0",
-  "description": "Simple Express for Docker",
-  "main": "server.js",
+  "description": "Simple Express app packaged with Docker, pushed to Amazon ECR by a Jenkins pipeline and a CircleCI workflow",
+  "main": "app.js",
+  "engines": {
+    "node": ">=14"
+  },
   "scripts": {
     "start": "node server.js",
-    "lint": "./node_modules/.bin/eslint server.js constants.js"
+    "test": "node test/smoke.js",
+    "lint": "eslint app.js server.js constants.js test"
   },
   "keywords": [
     "express",
-    "docker"
+    "docker",
+    "jenkins",
+    "circleci",
+    "ecr"
   ],
-  "author": "",
-  "license": "ISC",
+  "author": "alpersonalwebsite",
+  "license": "MIT",
   "dependencies": {
     "express": "^4.17.1"
   },

--- a/server.js
+++ b/server.js
@@ -1,13 +1,56 @@
-const express = require('express');
-const { HOST, PORT } = require('./constants')
+const app = require('./app');
+const { HOST, PORT } = require('./constants');
 
-const app = express();
-
-app.get('/', (req, res) => {
-  res.send('It is working!');
+// The success message goes in the listen callback, not after the call. `app.listen` is
+// asynchronous, so the old code logged "Running on http://0.0.0.0:8080" and then died
+// on the next tick if the port was taken. The README's own "check the logs" step used
+// that line as proof the container was working.
+const server = app.listen(PORT, HOST, () => {
+  console.log(`Running on http://${HOST}:${PORT}`);
 });
 
-app.listen(PORT, HOST);
-console.log(`Running on http://${HOST}:${PORT}`);
+// Without this handler the EADDRINUSE arrives as an uncaught exception and the reader
+// gets a stack trace where one line would do.
+server.on('error', (error) => {
+  console.error(`Cannot listen on ${HOST}:${PORT}: ${error.message}`);
+  process.exitCode = 1;
+});
 
-module.exports = app
+// Shut down on the signal `docker stop` sends, and this is worth more than a line of
+// explanation because the usual advice about it is wrong.
+//
+// A process running as PID 1 gets no default signal dispositions from the kernel, so a
+// SIGTERM it does not explicitly handle is discarded. Docker then waits out its grace
+// period and SIGKILLs. Measured on node:14 with `docker stop`:
+//
+//   CMD                                     stop time   exit code
+//   ["npm", "start"]                            0.15s   0
+//   ["node", "server.js"], no handler          10.24s   137 (SIGKILL)
+//   ["node", "server.js"] + docker run --init   0.19s   143
+//   ["node", "server.js"] + this handler        0.17s   0
+//
+// So "call node directly instead of npm" on its own makes shutdown ten seconds slower
+// and turns every stop into a kill, because npm is what was catching the signal. The
+// handler is the part that matters; the CMD change just removes a process from the
+// middle. (`npm start` is also not free of surprises: on npm 11 the same container
+// stops in 0.67s but exits 1, which an orchestrator reads as a crash.)
+//
+// server.close stops accepting new connections and waits for in-flight responses to
+// finish, which is the difference between a deploy that drops requests and one that
+// does not.
+const shutdown = (signal) => {
+  console.log(`${signal} received, closing the server`);
+
+  server.close((error) => {
+    if (error) {
+      console.error(`Error while closing: ${error.message}`);
+      process.exit(1);
+    }
+
+    process.exit(0);
+  });
+};
+
+['SIGTERM', 'SIGINT'].forEach((signal) => {
+  process.on(signal, () => shutdown(signal));
+});

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -1,0 +1,53 @@
+// A smoke test with no new dependencies: `assert` and `http` are both in the standard
+// library. jest plus supertest would be the conventional choice and would also be four
+// hundred packages, for three assertions, in a repo that deliberately keeps its 2020
+// dependency set. The CircleCI workflow was already named build_test_deploy and had no
+// test job, so this is the missing half of that name.
+//
+// Port 0 asks the OS for a free port, so the test never collides with a server the
+// reader happens to have running on 8080.
+const assert = require('assert');
+const http = require('http');
+
+const app = require('../app');
+
+const get = (port, path) => new Promise((resolve, reject) => {
+  const request = http.get({ host: '127.0.0.1', port, path }, (response) => {
+    let body = '';
+
+    response.setEncoding('utf8');
+    response.on('data', (chunk) => {
+      body += chunk;
+    });
+    response.on('end', () => resolve({ status: response.statusCode, body }));
+  });
+
+  request.on('error', reject);
+});
+
+const server = app.listen(0, '127.0.0.1', async () => {
+  const { port } = server.address();
+
+  try {
+    const root = await get(port, '/');
+    assert.strictEqual(root.status, 200);
+    assert.strictEqual(root.body, 'It is working!');
+
+    const health = await get(port, '/healthz');
+    assert.strictEqual(health.status, 200);
+    assert.deepStrictEqual(JSON.parse(health.body), { status: 'ok' });
+
+    // Express answers 404 for an unmatched route on its own. Asserting it catches the
+    // case where a future catch-all route swallows everything and makes the two checks
+    // above pass for the wrong reason.
+    const missing = await get(port, '/does-not-exist');
+    assert.strictEqual(missing.status, 404);
+
+    console.log('smoke: 5 assertions passed');
+  } catch (error) {
+    console.error(`smoke: FAILED ${error.message}`);
+    process.exitCode = 1;
+  } finally {
+    server.close();
+  }
+});

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -7,9 +7,21 @@
 // Port 0 asks the OS for a free port, so the test never collides with a server the
 // reader happens to have running on 8080.
 const assert = require('assert');
+const { spawnSync } = require('child_process');
 const http = require('http');
+const path = require('path');
 
 const app = require('../app');
+
+// constants.js is checked in a child process because it reads process.env at require
+// time, and a bad PORT is supposed to throw there rather than reach net.Server#listen,
+// which would throw synchronously inside app.listen and so escape the error handler
+// registered on the line after it.
+const requireConstantsWith = (port) => spawnSync(
+  process.execPath,
+  ['-e', 'require("./constants")'],
+  { cwd: path.join(__dirname, '..'), env: { ...process.env, PORT: port }, encoding: 'utf8' }
+);
 
 const get = (port, path) => new Promise((resolve, reject) => {
   const request = http.get({ host: '127.0.0.1', port, path }, (response) => {
@@ -43,7 +55,21 @@ const server = app.listen(0, '127.0.0.1', async () => {
     const missing = await get(port, '/does-not-exist');
     assert.strictEqual(missing.status, 404);
 
-    console.log('smoke: 5 assertions passed');
+    // Every one of these reached net.Server#listen and threw a RangeError before
+    // constants.js validated the value.
+    ['99999', 'Infinity', '8080.5', '-1', 'abc'].forEach((bad) => {
+      const result = requireConstantsWith(bad);
+      assert.strictEqual(result.status, 1, `PORT=${bad} should be rejected`);
+      assert.ok(
+        /PORT must be an integer between 1 and 65535/.test(result.stderr),
+        `PORT=${bad} should say why, got: ${result.stderr.split('\n')[0]}`
+      );
+    });
+
+    // Unset still falls back rather than throwing.
+    assert.strictEqual(requireConstantsWith('').status, 0);
+
+    console.log('smoke: 16 assertions passed');
   } catch (error) {
     console.error(`smoke: FAILED ${error.message}`);
     process.exitCode = 1;


### PR DESCRIPTION
The app is three files. Everything around it needed work: the image ran as root off a
moving base tag, the server logged a startup it had not achieved, both pipelines leaked
their ECR token into the build log, and the README's Jenkins install steps have not worked
for some years. No dependency was upgraded; `express` and `eslint` stay where they were and
the lockfile stays at `lockfileVersion` 1.

Twelve commits. The last three came out of review and are called out below, because one of
them fixes a bug in code introduced earlier in this same branch.

## Security

- **No AWS access key anywhere on the Jenkins side.** The README had you paste a key and
  secret into Jenkins twice (once as *AWS Credentials*, again at the end under *Configure
  CloudBees Credentials*, same ID), with no IAM policy shown, on a box whose job is running
  arbitrary shell. Jenkins runs on EC2 here, so it carries an instance role instead and gets
  short-lived rotated credentials from instance metadata. The `Jenkinsfile` names no
  credential at all.
- **No account ID committed either.** Both pipelines read it from
  `aws sts get-caller-identity`. A placeholder like `123456789012` in a committed pipeline is
  a thing to forget, and forgetting it means authenticating against and pushing to whatever
  account that is. Asking STS also fails immediately and legibly when no role or key is
  present.
- **An actual IAM policy**, six ECR actions on one repository ARN.
  `ecr:GetAuthorizationToken` is on `*` because it acts on no resource. The README also notes
  that an ECR repository ARN names a region, so the policy, `AWS_REGION` and the CircleCI
  `aws_region` parameter have to stay in step.
- **The token no longer reaches the build log.** Both pipelines used `aws ecr get-login`,
  which prints a `docker login -p <token>` command you then `eval`, so the token lands in the
  process list and in any log with command echoing on. Jenkins runs `sh` steps with `-x`, so
  that was not hypothetical. Both now pipe `get-login-password` into `--password-stdin`, and
  both log out from a shell `trap` so the credential does not survive in the agent's
  `~/.docker/config.json` after a failed push. AWS CLI v2 removed `get-login` outright; the
  old configs only worked because distro `awscli` is v1 (candidate `1.18.69` on 20.04).
- **Dropped the Docker Host URI step**, `tcp://172.17.0.40:2345` under Manage Jenkins →
  Clouds. An unauthenticated, unencrypted daemon socket is root on the host to anyone who can
  reach it, and the pipeline never needed it since `docker build`/`tag`/`push` go through the
  local CLI. It could not have worked as written either: Docker's TCP socket is 2375 or 2376,
  and it does not listen on TCP at all unless configured to.
- **The container no longer runs as root.** `docker run --rm web-app id` returned
  `uid=0(root)`; it is `uid=1000(node)` now, using the user the base image already ships.
- **`.git` no longer ships inside the image.** The old `.dockerignore` had two entries, so
  `COPY . .` copied 164K of full history plus the CI configs into an image bound for a
  registry. The Dockerfile copies the three source files by name, and `.dockerignore` is a
  real list as defence in depth.
- **No more `curl | sudo sh`.** Docker installs from its signed apt repository with the same
  `signed-by` shape as the Jenkins repo, rather than piping an unpinned remote program into
  root. `docker-ce` candidate `5:29.7.2-1~ubuntu.24.04~noble` resolves with no apt errors,
  and the codename comes from `/etc/os-release` rather than the hardcoded `bionic` the
  original had. The AWS CLI zip is not distributed through a repository, so its detached
  signature is verified before the installer runs.
- `.gitignore` gained `.env.*`, `*.pem`, `*.key`, `credentials*`, `secrets/`, `*.sqlite`,
  `*.db`, `__pycache__/` and `.DS_Store`. The keys matter here specifically: the walkthrough
  has you SSH with a `.pem`.

## Correctness

**The server logged success it did not have.** `console.log('Running on ...')` sat after
`app.listen`, which is asynchronous. Measured in the image with 8080 held:

```text
STDOUT: Running on http://0.0.0.0:8080
STDERR: events.js:377 ... EADDRINUSE
exit code: 1
```

The README's own "check what we are logging" step used that line as proof the container
worked. The message is in the `listen` callback now, with an `error` handler that says what
happened in one line.

**And that handler has a gap it cannot cover, which review caught.** `net.Server#listen`
rejects a bad port by throwing **synchronously**, inside the `app.listen` call, so it fires
before the `server.on('error')` line below it has run. `Number(process.env.PORT) || 8080`
accepted anything truthy, and all four of these threw `RangeError`: `99999`, `Infinity`,
`8080.5`, `-1`. `constants.js` now requires an integer in 1 to 65535 and throws with a
message naming the variable; unset still falls back, because a silent default turns a typo
in a deployment config into a service listening on the wrong port.

**Signals, where the usual advice turned out to be wrong.** A process as PID 1 gets no
default signal dispositions, so an unhandled SIGTERM is discarded. Measured on `node:14`
with `docker stop`:

| CMD | stop time | exit |
| --- | --- | --- |
| `["npm","start"]` (as committed) | 0.15s | 0 |
| `["node","server.js"]`, no handler | **10.24s** | **137** (SIGKILL) |
| `["node","server.js"]` + `--init` | 0.19s | 143 |
| `["node","server.js"]` + explicit handler | 0.17s | 0 |

So "do not use npm start as your CMD" on its own makes shutdown ten seconds slower and turns
every stop into a kill, because npm was the thing catching the signal. `server.js` has the
handler, and `server.close()` drains in-flight responses. (On npm 11 the old CMD stops in
0.67s but exits 1, which an orchestrator reads as a crash.)

**Base image pinned.** `node:latest` resolves to Node 26.7.0 today, twelve major versions
past the Node 14 the README's Jenkins tool configures, and it moved with no commit.
`node:14.21.3-alpine` has the same npm 6.14.18 and takes the image from **1266 MB to
120 MB**.

**`npm ci` everywhere.** The Dockerfile and both pipelines ran `npm install` with a lockfile
sitting right there.

**CircleCI persisted a directory that does not exist.** `persist_to_workspace` listed `src`,
and there is no `src/` in this repo. The downstream jobs only appeared to work because
`checkout` had already provided the sources.

**A test job, in a workflow already named `build_test_deploy`.** There was none, and nothing
to run in one. `test/smoke.js` uses `assert` and `http` only, no new dependencies: 16
assertions over `/`, `/healthz`, a 404, and five rejected `PORT` values. Verified
non-vacuous by poisoning the response body and the health payload.

**Splitting `app.js` from `server.js`** is what makes that possible: requiring the old file
took port 8080 as a side effect of the import.

**Images are tagged with the commit SHA**, not `:latest` only, so the registry records what
is deployed and a rollback exists. Jenkins also moves `:latest`; CircleCI deliberately does
not, because Jenkins has `disableConcurrentBuilds()` and CircleCI has no equivalent, so two
`master` workflows can be in the push job at once and an older one finishing last would walk
`:latest` backwards while both SHA tags stayed correct. The `Jenkinsfile` also gained
`timeout`, `buildDiscarder`, `disableConcurrentBuilds` and `timestamps`.

**A `HEALTHCHECK`** on `/healthz`, using the busybox `wget` already in the image. Verified in
both directions: probe exit 0 with the app up, exit 1 with nothing listening, and it follows
`PORT` when that is overridden.

**One thing that looked like a bug and was not.** The old `withAWS(credentials:
'MyAWSCredentials', , region: 'us-east-1')` has a stray double comma. Groovy 2.4 accepts it
and builds the identical argument map, Groovy 3.0 rejects it with `Unexpected input: '('`,
and current Jenkins LTS still ships `groovy-all-2.4.21` inside `jenkins.war`, so it parsed
fine on Jenkins all along. Removed as noise, and the file now parses under both.

## The README

Rewritten. It was "Simple `Express App`" plus install notes, with no way to run the app, no
mention of the two CI configs, and no explanation of the Dockerfile.

The Jenkins install steps did not work, and the reason is worth stating precisely because
most of the URLs still resolve. Following them verbatim on Ubuntu 20.04:

```text
W: GPG error: ... NO_PUBKEY 7198F4B714ABFC68
E: The repository 'http://pkg.jenkins-ci.org/debian binary/ Release' is not signed.
E: Package 'jenkins' has no installation candidate
```

`apt-key add` itself reported `OK`. Jenkins rotated its signing key. Also: `apt-key` is
deprecated and trusts the key for every repository rather than just Jenkins'; `default-jdk`
is Java 11.0.27 on 20.04 where current LTS needs 17 or 21 (and Java 21 on 24.04, so it fails
only on older releases, which is worse than failing everywhere); and the active `deb` line
pointed at the weekly channel while the commented-out one beside it pointed at
`debian-stable`. `pkg.jenkins-ci.org` is **not** dead, it redirects to `pkg.jenkins.io` in
three hops. The replacement steps resolved Jenkins 2.568.2 when tested, on both Ubuntu and
Amazon Linux 2023, which is a labelled second path now rather than an unexplained `yum`
block pasted into the middle of the Ubuntu one.

The Docker section never installed Docker: it ended at `apt-cache policy docker-ce`, which
only queries. Also fixed: `curl http://localhost:9090` after `docker run -p 8080:8080` with
a fabricated 200 under it; the 954MB size; a missing `unzip` that the AWS CLI step needed
and no prerequisite installed (verified absent from `ubuntu:24.04`, `ubuntu:20.04` and
`amazonlinux:2023`); the plugin list (eleven Blue Ocean plugins that Blue Ocean pulls in,
plus CloudBees AWS Credentials and Amazon ECR, neither needed now); `docker run --name
node-container -p 8000:8000 node:latest`, which starts a REPL with no TTY and exits; and two
dead references to an "application" repo, one a `git clone` URL. That project is this one,
renamed.

**Node 14 is end of life**, since 2023-04-30 per the Node.js release schedule, and the README
now says so in its second paragraph. The pin is deliberate: this repository exists to be its
2020 self done properly, and moving the runtime means moving `express`, the lockfile and both
CI images together. The README says to treat the image as a teaching artifact rather than a
production runtime, and lists what to change together if you do want to move it. On the same
note, the README states that a static CircleCI key is the period-accurate answer and not the
current one, names OIDC with `sts:AssumeRoleWithWebIdentity` as the modern shape, and gives
rotation guidance for the key if it stays.

## Verification

- `npm ci` under npm 6.14.18, `npm test` (16 assertions) and `npm run lint` all pass from a
  clean clone of the branch. Lockfile still `lockfileVersion` 1 and byte-identical apart from
  the `name` field.
- `hadolint` clean on the new Dockerfile; it flagged DL3007 on the old `FROM`.
- Image built, run, probed healthy, `curl` 200 on `/` and `/healthz`, stopped in 0.16s with
  exit 0 and `SIGTERM received, closing the server` in the log. `PORT=9000` binds with the
  health check following it; `PORT=99999` exits 1 with
  `RangeError: PORT must be an integer between 1 and 65535, received "99999"`.
- Contents of the new image: `app.js`, `constants.js`, `package.json`, `package-lock.json`,
  `server.js`, `node_modules`. No `.git`.
- `Jenkinsfile` parses under Groovy 2.4 and 3.0, with the checker proven non-vacuous against
  a deliberately broken file; its `sh` block passes `bash -n`.
- CircleCI config is valid YAML and all six `run` commands pass `bash -n`.
- Every fenced block in the README is syntax-checked: 10 shell, 1 JSON, 1 JS, no failures.
- `gitleaks` clean.

**Known gap: the CircleCI config has never executed.** All three builds on this branch fail
in CircleCI's own `checkout` step with `git@github.com: Permission denied (publickey)`,
before any line of the config runs. The project's deploy key needs re-authorizing in
CircleCI settings. This is not a regression, since master's config cannot run either for the
same reason, but the fixes in it are validated statically only.