### PR TITLE
Treat an empty PORT as a configuration error, not as unset

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -15,11 +15,26 @@ const DEFAULT_PORT = 8080;
 //   PORT=8080.5   -> 8080.5     RangeError
 //   PORT=-1       -> -1         RangeError
 //
-// Unset or empty falls back to the default. Set-but-invalid throws here instead, with
-// a message naming the variable, because silently falling back would turn a typo in a
-// deployment config into a service listening on the wrong port.
+// ONLY UNSET falls back to the default. Set-but-invalid throws here instead, with a message
+// naming the variable, because silently falling back would turn a typo in a deployment config
+// into a service listening on the wrong port.
+//
+// An empty or whitespace-only value counts as invalid, not as absent: something put that
+// variable there and produced nothing, which is a configuration mistake worth saying out loud.
+// This used to special-case `value === ''` and fall back, while a whitespace-only value threw,
+// and the inconsistency was accidental rather than intended: `Number('   ')` is 0, which fails
+// the range check below, whereas `''` never reached it. Measured before the change:
+//
+//   PORT unset   -> 8080, exit 0
+//   PORT=""      -> 8080, exit 0     silently defaulted
+//   PORT="   "   -> exit 1           threw, for the reason above rather than by design
+//
+// Two identical situations behaving differently, so the `=== ''` clause is gone and both now
+// throw. This also aligns with the readers in node-express-mongo-redis,
+// node-express-postgresql-docker-compose and basic-apollo-graphql, which were written with this
+// reasoning from the start and which this file diverged from.
 const readPort = (value) => {
-  if (value === undefined || value === '') {
+  if (value === undefined) {
     return DEFAULT_PORT;
   }
 

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -13,6 +13,12 @@ const path = require('path');
 
 const app = require('../app');
 
+// Set-but-empty and whitespace-only are in this list on purpose: see constants.js.
+const BAD_PORTS = ['99999', 'Infinity', '8080.5', '-1', 'abc', '', '   '];
+
+// The five request assertions below, kept beside the list so the printed total stays honest.
+const ROUTE_ASSERTIONS = 5;
+
 // constants.js is checked in a child process because it reads process.env at require
 // time, and a bad PORT is supposed to throw there rather than reach net.Server#listen,
 // which would throw synchronously inside app.listen and so escape the error handler
@@ -22,6 +28,20 @@ const requireConstantsWith = (port) => spawnSync(
   ['-e', 'require("./constants")'],
   { cwd: path.join(__dirname, '..'), env: { ...process.env, PORT: port }, encoding: 'utf8' }
 );
+
+// DELETING the key, not setting it to '', because those are now different cases and the previous
+// version of this test conflated them: it passed '' under a comment reading "Unset still falls back",
+// which asserted the empty-string behaviour while claiming to assert the unset one.
+const requireConstantsWithNoPort = () => {
+  const env = { ...process.env };
+  delete env.PORT;
+
+  return spawnSync(
+    process.execPath,
+    ['-e', 'require("./constants")'],
+    { cwd: path.join(__dirname, '..'), env, encoding: 'utf8' }
+  );
+};
 
 const get = (port, path) => new Promise((resolve, reject) => {
   const request = http.get({ host: '127.0.0.1', port, path }, (response) => {
@@ -56,8 +76,10 @@ const server = app.listen(0, '127.0.0.1', async () => {
     assert.strictEqual(missing.status, 404);
 
     // Every one of these reached net.Server#listen and threw a RangeError before
-    // constants.js validated the value.
-    ['99999', 'Infinity', '8080.5', '-1', 'abc'].forEach((bad) => {
+    // constants.js validated the value. The last two are set-but-empty: a variable that was
+    // provided and produced nothing, which is a configuration mistake rather than an absent
+    // setting, and which this file used to accept.
+    BAD_PORTS.forEach((bad) => {
       const result = requireConstantsWith(bad);
       assert.strictEqual(result.status, 1, `PORT=${bad} should be rejected`);
       assert.ok(
@@ -66,10 +88,11 @@ const server = app.listen(0, '127.0.0.1', async () => {
       );
     });
 
-    // Unset still falls back rather than throwing.
-    assert.strictEqual(requireConstantsWith('').status, 0);
+    // Genuinely unset, which is the only case that falls back rather than throwing.
+    assert.strictEqual(requireConstantsWithNoPort().status, 0);
 
-    console.log('smoke: 16 assertions passed');
+    // Counted rather than written down, so adding a case cannot leave a stale number here.
+    console.log(`smoke: ${ROUTE_ASSERTIONS + BAD_PORTS.length * 2 + 1} assertions passed`);
   } catch (error) {
     console.error(`smoke: FAILED ${error.message}`);
     process.exitCode = 1;


### PR DESCRIPTION
`readPort` special-cased `value === ''` and fell back to 8080, while a whitespace-only value threw.
Two identical situations behaving differently, and the difference was accidental rather than intended:
`Number('   ')` is `0`, which fails the range check, whereas `''` was caught by the guard and never
reached it.

| | before | after |
| --- | --- | --- |
| `PORT` unset | 8080, exit 0 | 8080, exit 0 |
| `PORT=""` | **8080, exit 0** | exit 1, `RangeError` naming PORT |
| `PORT="   "` | exit 1 | exit 1, `RangeError` naming PORT |

Only unset falls back now. A variable that was set and produced nothing is a configuration mistake:
something put it there, so saying so beats quietly listening on a different port than the deployment
asked for.

This is an alignment, not a discovery. `node-express-mongo-redis`,
`node-express-postgresql-docker-compose` and `basic-apollo-graphql` all received the same reader and
were written with this reasoning from the start. This file predates it and was the one out of step, and
that divergence was recorded in those PRs rather than left implicit. This closes it.

## The test was asserting the opposite, under a comment describing something else

```js
// Unset still falls back rather than throwing.
assert.strictEqual(requireConstantsWith('').status, 0);
```

That passes `PORT=''` through `spawnSync`'s `env`, so it **set** the variable to an empty string and
asserted the empty-string behaviour while claiming to cover the unset one. Those were the same case
when it was written; they are not any more.

There is now a separate helper that **deletes** the key to test genuinely unset, and `''` and `'   '`
have joined the rejected list.

The printed assertion total is computed from the list length rather than written down, so adding a case
cannot leave a stale number behind. Verified by adding one: 20 became 22.

## Checks

Poison-tested, each poison confirmed applied by `diff` before its result was read:

| poison | result |
| --- | --- |
| revert the reader so empty is accepted again | exit 1, `smoke: FAILED PORT= should be rejected` |
| restore the old empty-falls-back assertion | exit 1, fails on strict equality |
| add one bad port to the list | printed total moves 20 to 22, so the count is derived |

`npm test` passes at 20 assertions and `npm run lint` is clean.

## Not done

`HOST` is still read as `process.env.HOST || '0.0.0.0'`, so an empty `HOST` silently becomes the
default. Same reasoning would apply, but it is not a port and not what this change is about, so it is
left alone rather than folded in.
